### PR TITLE
Add missing -compile option

### DIFF
--- a/src/bin/main.sml
+++ b/src/bin/main.sml
@@ -187,6 +187,7 @@ in
                 "--" => ((#file d := hd xs) handle Empty => usage ())
               | "-ann" => l := ann (#rootAnns, "-ann") xs
               | "-c" => #cmd d := Compile
+              | "-compile" => #cmd d := Compile
               | "-default-ann" => l := ann (#defAnns, "default-ann") xs
               | "-deps-first" => #depsf d := true
               | "-disable-ann" => l := annName (#disAnns, "disable-ann") xs


### PR DESCRIPTION
The option `-compile` is already documented in the help as the long form of `-c`.