### PR TITLE
Ensure basis file has canonical path

### DIFF
--- a/src/lib/Basis.sml
+++ b/src/lib/Basis.sml
@@ -140,7 +140,7 @@ struct
           val t = ftype (s, exts, loc)
           val path =
             case Path.process m s of
-              Path.Path p => p
+              Path.Path p => OS.Path.mkCanonical p
             | Path.Unbound v => raise Validation (UnboundVariable, v, loc)
         in
           SOME (t, OS.Path.mkAbsolute { path = path, relativeTo = p })


### PR DESCRIPTION
Without this, the same MLB file can be elaborated multiple times due to different paths, which can cause type errors because there can be different instances of an abstract type that should be the same type.  Multiple paths to the same MLB file were observed under MSYS2 due to differences in case and file separator character, as shown in #12.